### PR TITLE
Add support to allow optional cidr block access to elasticsearch clusters

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -10,6 +10,7 @@
 |asg_max_size|The maximum instance count for the Autoscaling Group. It is recommended that this value and asg_min_size are the same.|No|3|aws_autoscaling_group.elasticsearch|
 |asg_min_size|The minimum instance count for the Autoscaling Group. It is recommended that this value and asg_max_size are the same.|No|3|aws_autoscaling_group.elasticsearch|
 |default_security_group_id|The optional ID of a security group that will override the default security group.|No|""|aws_launch_configuration.elasticsearch|
+|esclient_cidr_blocks|Comma separated list of cidr blocks that allow client access to the ES cluster.|No|127.0.0.1/32|aws_security_group_rule.elasticsearch_client_ingress_bycidr|
 |health_check_grace_period|Time after instance comes into service before checking health.|No|300|aws_autoscaling_group.elasticsearch|
 |name|The base name applied to resources.|No|elasticsearch|aws_autoscaling_group.elasticsearch, aws_elb.elasticsearch, aws_iam_instance_profile.elasticsearch, aws_iam_role.elasticsearch, aws_iam_role_policy.elasticsearch, aws_launch_configuration.elasticsearch, aws_route53_record.elasticsearch, aws_security_group.default, aws_security_group.elasticsearch_client, aws_security_group.elasticsearch_cluster|
 |user_data|The user data to provide when launching the instance.|No|""|aws_launch_configuration.elasticsearch|

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -75,6 +75,16 @@ resource "aws_security_group_rule" "elasticsearch_client_ingress" {
   source_security_group_id = "${aws_security_group.elasticsearch_client.id}"
 }
 
+resource "aws_security_group_rule" "elasticsearch_client_ingress_bycidr" {
+  type      = "ingress"
+  from_port = 9200
+  to_port   = 9200
+  protocol  = "tcp"
+  cidr_blocks = ["${split(",", var.esclient_cidr_blocks)}"]
+
+  security_group_id        = "${aws_security_group.elasticsearch_cluster.id}"
+}
+
 resource "aws_security_group_rule" "elasticsearch_client_egress" {
   type      = "egress"
   from_port = 9200

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,12 @@ variable "default_security_group_id" {
   default     = ""
 }
 
+variable "esclient_cidr_blocks" {
+  description = "Comma separated list of cidr blocks that allow client access to the ES cluster."
+  type        = "string"
+  default     = "127.0.0.1/32"
+}
+
 variable "health_check_grace_period" {
   description = "Time after instance comes into service before checking health."
   type        = "string"


### PR DESCRIPTION
Some use-cases require access to the elasticsearch cluster without a IAM, for example, for legacy networks or externally available on the internet.
